### PR TITLE
Add base_path such that assets work when mounted

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,7 +8,8 @@ require 'byebug' if development?
 
 class OffsiteGatewaySim < Sinatra::Base
 
-  def initialize
+  def initialize(base_path: '')
+    @base_path = base_path
     @key = 'iU44RWxeik'
     super
   end

--- a/views/get.erb
+++ b/views/get.erb
@@ -7,5 +7,5 @@
     <br/>
     <span><strong>POST URL</strong>: <code>https://offsite-gateway-sim.herokuapp.com/</code> <i>(or leave empty)</i>
   </p>
-  <img src="/dev-kit-screenshot.png"/>
+  <img src="<%= @base_path %>/dev-kit-screenshot.png"/>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -6,15 +6,15 @@
   <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" >
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Varela+Round">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro">
-  <link rel="stylesheet" href="/pure-min.css">
-  <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/tipr.css">
+  <link rel="stylesheet" href="<%= @base_path %>/pure-min.css">
+  <link rel="stylesheet" href="<%= @base_path %>/style.css">
+  <link rel="stylesheet" href="<%= @base_path %>/tipr.css">
 </head>
 <body>
 <div class="pure-g">
   <div class="pure-u-1-1 main-box">
     <div class="center">
-      <img style="vertical-align: middle;" src="/shopify.png"/>
+      <img style="vertical-align: middle;" src="<%= @base_path %>/shopify.png"/>
       <span class="title">offsite gateway sim</span>
       <a class="pure-button button-small" href="https://github.com/Shopify/offsite-gateway-sim">
           <i class="fa fa-github"></i>
@@ -25,7 +25,7 @@
   </div>
 </div>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-<script src="/tipr.js"></script>
+<script src="<%= @base_path %>/tipr.js"></script>
 <script>
   $(document).ready(function() {
     $('.tip').tipr();

--- a/views/post.erb
+++ b/views/post.erb
@@ -13,7 +13,7 @@
               <td><code><%= k %></code></td>
               <td>
                 <% if k == 'x_signature' %>
-                  <img style="vertical-align: middle;" src="/<%= signature_ok ? 'yes' : 'no' %>.png"/>
+                <img style="vertical-align: middle;" src="<%= @base_path %>/<%= signature_ok ? 'yes' : 'no' %>.png"/>
                 <% end %>
                 <code><%= v %></code>
               </td>


### PR DESCRIPTION
I'm working on making `offsite-gateway-sim` mountable within a rails app by doing this:

```ruby
mount OffsiteGatewaySim, at: '/offsite_gateway_sim'
```

This worked fine, but assets were not loading correctly because they are hardcoded to `/file.ext`.

I've added a `base_path` option so that we can do:

```ruby
mount OffsiteGatewaySim.new(base_path: '/offsite_gateway_sim'), at: '/offsite_gateway_sim'
```

### Review

@volmer @christianblais does this make sense to you?

I've :tophat: in Shopify/shopify and it works.